### PR TITLE
enforce domain expiration settings on a role by default

### DIFF
--- a/ui/src/components/review/ReviewList.js
+++ b/ui/src/components/review/ReviewList.js
@@ -85,7 +85,7 @@ class ReviewList extends React.Component {
     }
 
     render() {
-        const { domain, collection, collectionDetails } = this.props;
+        const { domain, collection, collectionDetails, domainExpiration } = this.props;
         return this.props.isLoading.length !== 0 ? (
             <ReduxPageLoader message={'Loading data'} />
         ) : (
@@ -109,6 +109,7 @@ class ReviewList extends React.Component {
                 {this.props.category === 'role' && (
                     <ReviewTable
                         domain={domain}
+                        domainExpiration={domainExpiration}
                         role={collection}
                         roleDetails={collectionDetails}
                         members={this.props.members}
@@ -117,10 +118,8 @@ class ReviewList extends React.Component {
                         onUpdateSuccess={this.submitSuccess}
                         justification={this.props.justification}
                         expiryOrReviewSettingIsSet={
-                            0 <
-                            getSmallestExpiryOrReview(
-                                this.props.collectionDetails
-                            )
+                            !!getSmallestExpiryOrReview(collectionDetails) ||
+                            !!getSmallestExpiryOrReview(domainExpiration)
                         }
                     />
                 )}

--- a/ui/src/components/review/ReviewTable.js
+++ b/ui/src/components/review/ReviewTable.js
@@ -26,7 +26,7 @@ import { connect } from 'react-redux';
 import { reviewRole } from '../../redux/thunks/roles';
 import produce from 'immer';
 import DeleteModal from '../modal/DeleteModal';
-import CollectionUtils from 'lodash';
+import { domainExpirationIsConfigured, roleExpirationIsConfigured } from '../utils/ReviewUtils';
 
 const TitleDiv = styled.div`
     font-size: 16px;
@@ -231,70 +231,62 @@ export class ReviewTable extends React.Component {
     }
 
     getDefaultExpiryText() {
+        const { roleDetails, domainExpiration } = this.props;
         let text = 'Current default settings are - ';
-        let noDaysConfigured = true;
-        if (this.props.roleDetails && this.props.roleDetails.memberExpiryDays) {
-            text =
-                text +
-                'Member Expiry: ' +
-                this.props.roleDetails.memberExpiryDays +
-                ' days. ';
-            noDaysConfigured = false;
+
+        if (roleDetails?.memberExpiryDays) {
+            text += `Member Expiry: ${roleDetails.memberExpiryDays} days. `;
         }
-        if (
-            this.props.roleDetails &&
-            this.props.roleDetails.serviceExpiryDays
+
+        if (roleDetails?.serviceExpiryDays) {
+            text += `Service Expiry: ${roleDetails.serviceExpiryDays} days. `;
+        }
+
+        if (roleDetails?.groupExpiryDays) {
+            text += `Group Expiry: ${roleDetails.groupExpiryDays} days. `;
+        }
+
+        if (roleDetails?.memberReviewDays) {
+            text += `Member Review: ${roleDetails.memberReviewDays} days. `;
+        }
+
+        if (roleDetails?.serviceReviewDays) {
+            text += `Service Review: ${roleDetails.serviceReviewDays} days. `;
+        }
+
+        if (roleDetails?.groupReviewDays) {
+            text += `Group Review: ${roleDetails.groupReviewDays} days. `;
+        }
+
+        // if role expiration is not configured, default to domain expiration
+        if (!roleExpirationIsConfigured(roleDetails) &&
+            domainExpirationIsConfigured(domainExpiration)) {
+            text = 'Current domain settings are - ';
+
+            if (domainExpiration.memberExpiryDays) {
+                text += `Domain Member Expiry: ${domainExpiration.memberExpiryDays} days. `;
+            }
+
+            if (domainExpiration.serviceExpiryDays) {
+                text += `Domain Service Expiry: ${domainExpiration.serviceExpiryDays} days. `;
+            }
+
+            if (domainExpiration.groupExpiryDays) {
+                text += `Domain Group Expiry: ${domainExpiration.groupExpiryDays} days. `;
+            }
+        }
+
+        // if neither role nor domain expiration settings are configured
+        if (!roleExpirationIsConfigured(roleDetails) &&
+            !domainExpirationIsConfigured(domainExpiration)
         ) {
-            text =
-                text +
-                'Service Expiry: ' +
-                this.props.roleDetails.serviceExpiryDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
-        if (this.props.roleDetails && this.props.roleDetails.groupExpiryDays) {
-            text =
-                text +
-                'Group Expiry: ' +
-                this.props.roleDetails.groupExpiryDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
-        if (this.props.roleDetails && this.props.roleDetails.memberReviewDays) {
-            text =
-                text +
-                'Member Review: ' +
-                this.props.roleDetails.memberReviewDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
-        if (
-            this.props.roleDetails &&
-            this.props.roleDetails.serviceReviewDays
-        ) {
-            text =
-                text +
-                'Service Review: ' +
-                this.props.roleDetails.serviceReviewDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
-        if (this.props.roleDetails && this.props.roleDetails.groupReviewDays) {
-            text =
-                text +
-                'Group Review: ' +
-                this.props.roleDetails.groupReviewDays +
-                ' days. ';
-            noDaysConfigured = false;
-        }
-        if (noDaysConfigured) {
             text = text + 'None';
         }
 
-        const changeText = 'To change it, please click ';
+        const changeText = 'To change it for the role, please click ';
 
         return (
-            <SubmitTextSpan>
+            <SubmitTextSpan data-testid='role-expiration-details'>
                 {text}
                 <br />
                 {changeText}

--- a/ui/src/components/utils/ReviewUtils.js
+++ b/ui/src/components/utils/ReviewUtils.js
@@ -47,14 +47,34 @@ export function isReviewRequired(roleOrGroup) {
         .isAfter(lastReviewedDate);
 }
 
+export function domainExpirationIsConfigured(domain) {
+    return !!domain.memberExpiryDays ||
+        !!domain.groupExpiryDays ||
+        !!domain.serviceExpiryDays;
+}
+
+export function roleExpirationIsConfigured(roleDetails) {
+    return !!roleDetails?.memberExpiryDays || !!roleDetails?.memberReviewDays ||
+        !!roleDetails?.groupExpiryDays || !!roleDetails?.groupReviewDays ||
+        !!roleDetails?.serviceExpiryDays || !!roleDetails?.serviceReviewDays;
+}
+
+export function getExpirationFromDomain(domainData) {
+    return {
+        groupExpiryDays: Number(domainData?.groupExpiryDays) || 0,
+        memberExpiryDays: Number(domainData?.memberExpiryDays) || 0,
+        serviceExpiryDays: Number(domainData?.serviceExpiryDays) || 0,
+    }
+}
+
 export function getSmallestExpiryOrReview(roleOrGroup) {
     const values = [
-        roleOrGroup.memberExpiryDays,
-        roleOrGroup.memberReviewDays,
-        roleOrGroup.groupExpiryDays,
-        roleOrGroup.groupReviewDays,
-        roleOrGroup.serviceExpiryDays,
-        roleOrGroup.serviceReviewDays,
+        roleOrGroup?.memberExpiryDays || 0,
+        roleOrGroup?.memberReviewDays || 0,
+        roleOrGroup?.groupExpiryDays || 0,
+        roleOrGroup?.groupReviewDays || 0,
+        roleOrGroup?.serviceExpiryDays || 0,
+        roleOrGroup?.serviceReviewDays || 0,
     ].filter((obj) => obj > 0); // pick only those that have days set and days > 0
 
     if (values.length > 0) {

--- a/ui/src/pages/domain/[domain]/role/[role]/review.js
+++ b/ui/src/pages/domain/[domain]/role/[role]/review.js
@@ -32,12 +32,12 @@ import { connect } from 'react-redux';
 import {
     selectReviewRoleMembers,
     selectRole,
-    selectRoleMembers,
 } from '../../../../../redux/selectors/roles';
 import { getRole } from '../../../../../redux/thunks/roles';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { ReduxPageLoader } from '../../../../../components/denali/ReduxPageLoader';
+import { getExpirationFromDomain } from '../../../../../components/utils/ReviewUtils';
 
 const AppContainerDiv = styled.div`
     align-items: stretch;
@@ -131,6 +131,7 @@ class ReviewPage extends React.Component {
             members,
             _csrf,
             isLoading,
+            domainData,
         } = this.props;
         if (reload || this.state.reload) {
             window.location.reload();
@@ -173,6 +174,7 @@ class ReviewPage extends React.Component {
                                     </PageHeaderDiv>
                                     <ReviewList
                                         domain={domainName}
+                                        domainExpiration={getExpirationFromDomain(domainData)}
                                         collection={roleName}
                                         collectionDetails={roleDetails}
                                         members={members}
@@ -200,6 +202,7 @@ const mapStateToProps = (state, props) => {
             props.domainName,
             props.roleName
         ),
+        domainData: state?.domainData?.domainData,
     };
 };
 


### PR DESCRIPTION
# Description
- Domain expiration settings are enforced by default if no role specific expiration settings are configured.
- Extend radio button is enabled to reflect this

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 
Role expiration is not configured
<img width="1695" alt="image" src="https://github.com/user-attachments/assets/8784e2ff-106d-4062-9e3e-88d249a4cc70" />

Domain expiration is configured
<img width="1695" alt="image" src="https://github.com/user-attachments/assets/7f38c6a0-5154-427c-bf0b-b2ea45d0804e" />

Domain expiration settings being enforced on the role
<img width="1695" alt="image" src="https://github.com/user-attachments/assets/ecb7506f-be31-4079-8b00-24904baca090" />